### PR TITLE
Validate schema for all credentials in chain

### DIFF
--- a/src/lib/engine/validate-extended-credential.ts
+++ b/src/lib/engine/validate-extended-credential.ts
@@ -1,11 +1,12 @@
 import { rulesEngineManager } from "../rules-definition/rules-manager.js";
-import { getCredentialRuleSchemaChain, getCredentialType, GS1_PREFIX_LICENSE_CREDENTIAL } from "../get-credential-type.js";
+import { getCredentialRuleSchemaChain, getCredentialType, getCredentialRuleSchema, GS1_PREFIX_LICENSE_CREDENTIAL } from "../get-credential-type.js";
 import { CredentialSubjectSchema, gs1CredentialSchemaChain, propertyMetaData } from "../rules-schema/rules-schema-types.js";
 import { invalidGS1CredentialTypes, invalidRootCredentialType, unsupportedCredentialChain } from "./gs1-credential-errors.js";
 import { resolveExternalCredential } from "./resolve-external-credential.js";
 import { formateConsoleLog } from "../utility/console-logger.js";
-import { CredentialPresentation, VerifiableCredential, externalCredential, gs1RulesResult, verifiableJwt, verifyExternalCredential } from "../types.js";
+import { CredentialPresentation, VerifiableCredential, externalCredential, gs1RulesResult, verifiableJwt, verifyExternalCredential, jsonSchemaLoader } from "../types.js";
 import { normalizeCredential } from "../utility/jwt-utils.js";
+import { checkSchema } from "../schema/validate-schema.js";
 
 // Metadata for the Credential Chain
 export type credentialChainMetaData = {
@@ -69,7 +70,7 @@ export async function buildCredentialChain(externalCredentialLoader: externalCre
 // GS1 Credential chain requires validation between different credential types (See GS1 Data Model for More Details)
 // - Validate Credential Types between parent and child extended credentials
 // - Validate Credential Subject between parent and child extended credentials (See GS1 Data Model for More Details)
-export async function validateCredentialChain(externalCredentialVerification: verifyExternalCredential, credentialChain: credentialChainMetaData, validateChain: boolean) : Promise<gs1RulesResult> {
+export async function validateCredentialChain(externalCredentialVerification: verifyExternalCredential, credentialChain: credentialChainMetaData, validateChain: boolean, jsonSchemaLoader?: jsonSchemaLoader, fullJsonSchemaValidationOn: boolean = true) : Promise<gs1RulesResult> {
 
     const credential = credentialChain.credential
     const decodedCredential: VerifiableCredential = normalizeCredential(credential);
@@ -87,8 +88,21 @@ export async function validateCredentialChain(externalCredentialVerification: ve
         }
     }
 
+    // Validate schema for credentials in the chain (if schema loader is provided)
+    if (jsonSchemaLoader) {
+        const credentialSchema = getCredentialRuleSchema(jsonSchemaLoader, decodedCredential, fullJsonSchemaValidationOn);
+        const schemaCheckResult = await checkSchema(credentialSchema, decodedCredential);
+        
+        if (!schemaCheckResult.verified) {
+            gs1CredentialCheck.errors = gs1CredentialCheck.errors.concat(schemaCheckResult.errors);
+        }
+    }
+
     // When there is no extended credential exit out of the chain
     if (!decodedExtendedCredential) {
+        if (gs1CredentialCheck.errors.length > 0) {
+            gs1CredentialCheck.verified = false;
+        }
         return gs1CredentialCheck;
     }
 
@@ -137,7 +151,7 @@ export async function validateCredentialChain(externalCredentialVerification: ve
   
     // Walk Up Credential Chain until we reach the root credential
     if (credentialChain.extendedCredentialChain?.extendedCredentialChain) {
-        const validateExtendedCredentialResult = await validateCredentialChain(externalCredentialVerification, credentialChain.extendedCredentialChain, false);
+        const validateExtendedCredentialResult = await validateCredentialChain(externalCredentialVerification, credentialChain.extendedCredentialChain, false, jsonSchemaLoader, fullJsonSchemaValidationOn);
 
         // When Resolve VC is not in the presentation add to the output
         if (!credentialChain.extendedCredentialChain?.extendedCredentialChain.inPresentation) {
@@ -166,7 +180,7 @@ export async function validateCredentialChain(externalCredentialVerification: ve
         }
 
         if (credentialChain.extendedCredentialChain && credentialChain.extendedCredentialChain.credentialSubjectSchema) {
-            const validateExtendedCredentialResult = await validateCredentialChain(externalCredentialVerification, credentialChain.extendedCredentialChain, false);
+            const validateExtendedCredentialResult = await validateCredentialChain(externalCredentialVerification, credentialChain.extendedCredentialChain, false, jsonSchemaLoader, fullJsonSchemaValidationOn);
 
             // When Resolve VC is not in the presentation add to the output
             if (!credentialChain.extendedCredentialChain.inPresentation) {
@@ -187,7 +201,9 @@ export async function validateCredentialChain(externalCredentialVerification: ve
 
         }
     }
-   
+    if (gs1CredentialCheck.errors.length > 0) {
+        gs1CredentialCheck.verified = false;
+    }
     return gs1CredentialCheck;
 }
 

--- a/src/lib/gs1-verification-service.ts
+++ b/src/lib/gs1-verification-service.ts
@@ -41,16 +41,9 @@ async function checkGS1Credentials(validatorRequest: gs1ValidatorRequest, verifi
 
     const gs1CredentialCheck: gs1RulesResult = { credentialId : decodedCredential.id, credentialName: credentialSchema.title ? credentialSchema.title : "unknown", verified: true, errors: []};
 
-    // Enforce GS1 Credential JSON Schema Rules
-    const schemaCheckResult = await checkSchema(credentialSchema, decodedCredential);
-
-    if (!schemaCheckResult.verified) { 
-       gs1CredentialCheck.errors = schemaCheckResult.errors;
-   }
-
     const credentialChain = await buildCredentialChain(externalCredentialLoader, decodedPresentation, decodedCredential);
     if (!credentialChain.error) {
-        const extendedCredentialResult = await validateCredentialChain(externalCredentialVerification, credentialChain, true);
+        const extendedCredentialResult = await validateCredentialChain(externalCredentialVerification, credentialChain, true, jsonSchemaLoader, validatorRequest.fullJsonSchemaValidationOn);
 
         gs1CredentialCheck.resolvedCredential = extendedCredentialResult.resolvedCredential;
         if (!extendedCredentialResult.verified) {

--- a/src/lib/schema/validate-schema.ts
+++ b/src/lib/schema/validate-schema.ts
@@ -28,7 +28,7 @@ export async function checkSchema(schemaToValidate: gs1CredentialSchema, credent
       if (jsonSchemaError.isGS1Error && jsonSchemaError.gs1Rule !== undefined) {
         gs1CredentialCheck.errors.push(jsonSchemaError.gs1Rule);
       } else {
-        const jsonSchemaErrorRule = { code: errorResolveCredentialCode, rule: `${error.instancePath} ${error.message}`};
+        const jsonSchemaErrorRule = { code: errorResolveCredentialCode, rule: `${error.instancePath} ${error.message}`, credentialId: credential.id };
         gs1CredentialCheck.errors.push(jsonSchemaErrorRule);
       }
     });


### PR DESCRIPTION
Fixes issue where only the root credential was being schema validated while extended credentials in the chain were skipped.

- Move schema validation from checkGS1Credentials to validateCredentialChain
- Ensure every credential in the chain gets schema validation, not just the first one
- Add credentialId to schema validation errors for better traceability
- Pass jsonSchemaLoader and fullJsonSchemaValidationOn through recursive calls
